### PR TITLE
Improve bottom panel layout for readability

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,6 +28,12 @@ void cdft(int, int, double *, int *, double *);
 #define MAX_LOG_ENTRIES 10
 #define EVENT_HISTORY_SIZE 50
 #define PATTERN_LENGTH 3
+#define PANEL_TOP (WATERFALL_HEIGHT + 15)
+#define LEFT_COL_X 15
+#define MID_COL_X 355
+#define RIGHT_COL_X 755
+#define MID_SEP_X 340
+#define RIGHT_SEP_X 730
 
 // Audio processing constants
 #define SAMPLE_RATE 44100
@@ -399,36 +405,43 @@ void render(int has_new_data) {
     SDL_RenderCopy(g_renderer, g_waterfall_texture, NULL, &(SDL_Rect){0, 0, SCREEN_WIDTH, WATERFALL_HEIGHT});
 
     SDL_SetRenderDrawColor(g_renderer, grid_color.r, grid_color.g, grid_color.b, 255);
-    for (int x = 0; x < SCREEN_WIDTH; x += 50) SDL_RenderDrawLine(g_renderer, x, 0, x, SCREEN_HEIGHT);
-    for (int y = 0; y < SCREEN_HEIGHT; y += 50) SDL_RenderDrawLine(g_renderer, 0, y, SCREEN_WIDTH, y);
+    for (int x = 0; x < SCREEN_WIDTH; x += 50) SDL_RenderDrawLine(g_renderer, x, 0, x, WATERFALL_HEIGHT);
+    for (int y = 0; y < WATERFALL_HEIGHT; y += 50) SDL_RenderDrawLine(g_renderer, 0, y, SCREEN_WIDTH, y);
+
+    SDL_Rect panel = {0, WATERFALL_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT - WATERFALL_HEIGHT};
+    SDL_SetRenderDrawColor(g_renderer, 0, 0, 0, 200);
+    SDL_RenderFillRect(g_renderer, &panel);
+    SDL_SetRenderDrawColor(g_renderer, grid_color.r, grid_color.g, grid_color.b, 255);
+    SDL_RenderDrawLine(g_renderer, MID_SEP_X, WATERFALL_HEIGHT, MID_SEP_X, SCREEN_HEIGHT);
+    SDL_RenderDrawLine(g_renderer, RIGHT_SEP_X, WATERFALL_HEIGHT, RIGHT_SEP_X, SCREEN_HEIGHT);
 
     char buffer[100];
     int current_y;
 
     // Left Column
-    render_text("STATUS & CONTROLS", 10, WATERFALL_HEIGHT + 20, g_font_medium, highlight_color);
+    render_text("STATUS & CONTROLS", LEFT_COL_X - 5, PANEL_TOP, g_font_medium, highlight_color);
     sprintf(buffer, "Input Gain: %+.1f dB (Up/Down)", g_input_gain_db);
-    render_text(buffer, 15, WATERFALL_HEIGHT + 50, g_font_small, text_color);
+    render_text(buffer, LEFT_COL_X, PANEL_TOP + 30, g_font_small, text_color);
     sprintf(buffer, "Burst Threshold: %+.1f dB (Left/Right)", g_burst_threshold_db);
-    render_text(buffer, 15, WATERFALL_HEIGHT + 70, g_font_small, text_color);
+    render_text(buffer, LEFT_COL_X, PANEL_TOP + 50, g_font_small, text_color);
     if (g_burst_state == STATE_BURST) {
-        render_text("STATE: BURST DETECTED", 15, WATERFALL_HEIGHT + 90, g_font_small, highlight_color);
+        render_text("STATE: BURST DETECTED", LEFT_COL_X, PANEL_TOP + 70, g_font_small, highlight_color);
     } else {
-        render_text("STATE: Monitoring...", 15, WATERFALL_HEIGHT + 90, g_font_small, text_color);
+        render_text("STATE: Monitoring...", LEFT_COL_X, PANEL_TOP + 70, g_font_small, text_color);
     }
 
     // Middle Column
-    current_y = WATERFALL_HEIGHT + 20;
-    render_text("REAL-TIME ANALYSIS", 350, current_y, g_font_medium, highlight_color);
+    current_y = PANEL_TOP;
+    render_text("REAL-TIME ANALYSIS", MID_COL_X - 5, current_y, g_font_medium, highlight_color);
     current_y += 30;
     sprintf(buffer, "Peak Frequency: %.2f Hz", g_peak_freq);
-    render_text(buffer, 355, current_y, g_font_small, text_color);
+    render_text(buffer, MID_COL_X, current_y, g_font_small, text_color);
     current_y += 20;
     sprintf(buffer, "Peak Magnitude: %.2f dB", g_peak_mag);
-    render_text(buffer, 355, current_y, g_font_small, text_color);
+    render_text(buffer, MID_COL_X, current_y, g_font_small, text_color);
 
     current_y += 40;
-    render_text("PATTERN ANALYSIS", 350, current_y, g_font_medium, highlight_color);
+    render_text("PATTERN ANALYSIS", MID_COL_X - 5, current_y, g_font_medium, highlight_color);
     current_y += 30;
     if (g_pattern_reps > 1) {
         char pattern_str[50] = "PATTERN: [";
@@ -442,15 +455,15 @@ void render(int has_new_data) {
         }
         strcat(pattern_str, "]");
         sprintf(buffer, "%s (x%d)", pattern_str, g_pattern_reps);
-        render_text(buffer, 355, current_y, g_font_small, highlight_color);
+        render_text(buffer, MID_COL_X, current_y, g_font_small, highlight_color);
     } else {
-        render_text("Searching for patterns...", 355, current_y, g_font_small, text_color);
+        render_text("Searching for patterns...", MID_COL_X, current_y, g_font_small, text_color);
     }
 
     // Right Column
-    render_text("EVENT LOG", 750, WATERFALL_HEIGHT + 20, g_font_medium, highlight_color);
+    render_text("EVENT LOG", RIGHT_COL_X - 5, PANEL_TOP, g_font_medium, highlight_color);
     for (int i = 0; i < g_event_log_pos; i++) {
-        render_text(g_event_log[i], 755, WATERFALL_HEIGHT + 50 + (i * 20), g_font_small, text_color);
+        render_text(g_event_log[i], RIGHT_COL_X, PANEL_TOP + 30 + (i * 20), g_font_small, text_color);
     }
 
     SDL_RenderPresent(g_renderer);


### PR DESCRIPTION
## Summary
- Add constants for bottom panel and column positions
- Render semi-transparent bottom panel with column separators
- Align status, analysis, and event log text using new layout constants

## Testing
- `make`
- `./ghost` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a100d611208326b3e4dac5771440e3