### PR TITLE
Fix FFT work array size to prevent overflow

### DIFF
--- a/main.c
+++ b/main.c
@@ -109,7 +109,10 @@ int g_is_paused = 0;
 
 // FFT work arrays
 int g_fft_ip[FFT_SIZE + 2];
-double g_fft_w[FFT_SIZE * 5 / 4];
+// Ooura's FFT requires a work array of size n*5/4, where n is the value
+// passed to cdft(). We call cdft() with n = FFT_SIZE * 2, so allocate
+// FFT_SIZE * 5 / 2 elements to avoid buffer overruns.
+double g_fft_w[FFT_SIZE * 5 / 2];
 
 // --- Function Prototypes ---
 int init();


### PR DESCRIPTION
## Summary
- Allocate a larger FFT work array so Ooura's cdft() does not write past the buffer
- Document the reasoning behind the required size

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a20a1a05008326809bef79bd5a0a8d